### PR TITLE
Add setup script for running Puppeteer tests as non-root

### DIFF
--- a/setup-tests.sh
+++ b/setup-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Setup script to run Puppeteer tests as the non-root tester user.
+# Puppeteer requires a non-root environment to launch Chromium.
+
+set -e
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Create the tester user if it doesn't exist
+if ! id -u tester >/dev/null 2>&1; then
+  useradd -m tester
+fi
+
+# Install required system dependencies for Chromium
+apt-get update
+apt-get install -y \
+  nodejs \
+  npm \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libxkbcommon0 \
+  libx11-xcb1 \
+  libxcb1 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxrandr2 \
+  libgbm1 \
+  libnss3 \
+  libgtk-3-0 \
+  libxss1
+
+# Install the Chromium browser required by Puppeteer
+su -s /bin/bash tester -c "cd \"$PROJECT_DIR\" && npx puppeteer browsers install chrome"
+
+# Run the Puppeteer tests as the tester user
+su -s /bin/bash tester -c "cd \"$PROJECT_DIR\" && npm test"


### PR DESCRIPTION
## Summary
- Set up Puppeteer tests to run under a non-root tester user
- Install Node.js, Chromium deps, and attempt to fetch a browser for Puppeteer before testing

## Testing
- `./setup-tests.sh` *(fails: Download failed 403 from https://edgedl.me.gvt1.com)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b349f934948323b71fc0f33c7a797a