### PR TITLE
Add goblin sprite animations for player

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -7,17 +7,36 @@ export default class Player {
         this.x = canvas.width / 2;
         this.y = canvas.height / 2;
         this.speed = 3;
-        this.size = 20;
+        this.frameWidth = 32;
+        this.frameHeight = 32;
+        this.size = this.frameWidth / 2;
         this.fireCooldown = 0;
         this.weapon = 'inferno';
+
+        this.sprite = new Image();
+        this.sprite.src = 'img/sprite-goblin.png';
+        this.animations = {
+            idle: { row: 0, frames: 3 },
+            walk: { row: 1, frames: 6 },
+            attack: { row: 2, frames: 3 },
+            hurt: { row: 3, frames: 1 },
+            death: { row: 4, frames: 2 }
+        };
+        this.state = 'idle';
+        this.frame = 0;
+        this.frameTimer = 0;
+        this.frameInterval = 10;
     }
 
     update() {
         const keys = this.gameState.keys;
-        if (keys['KeyW']) this.y -= this.speed;
-        if (keys['KeyS']) this.y += this.speed;
-        if (keys['KeyA']) this.x -= this.speed;
-        if (keys['KeyD']) this.x += this.speed;
+        let moving = false;
+        if (keys['KeyW']) { this.y -= this.speed; moving = true; }
+        if (keys['KeyS']) { this.y += this.speed; moving = true; }
+        if (keys['KeyA']) { this.x -= this.speed; moving = true; }
+        if (keys['KeyD']) { this.x += this.speed; moving = true; }
+
+        this.state = moving ? 'walk' : 'idle';
 
         this.x = Math.max(this.size, Math.min(this.canvas.width - this.size, this.x));
         this.y = Math.max(this.size, Math.min(this.canvas.height - this.size, this.y));
@@ -36,12 +55,34 @@ export default class Player {
         } else {
             this.fireCooldown--;
         }
+
+        this.frameTimer++;
+        if (this.frameTimer >= this.frameInterval) {
+            this.frameTimer = 0;
+            const animation = this.animations[this.state];
+            this.frame = (this.frame + 1) % animation.frames;
+        }
     }
 
     draw(ctx) {
-        ctx.fillStyle = 'lime';
-        ctx.beginPath();
-        ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
-        ctx.fill();
+        const animation = this.animations[this.state];
+        if (this.sprite.complete) {
+            ctx.drawImage(
+                this.sprite,
+                this.frame * this.frameWidth,
+                animation.row * this.frameHeight,
+                this.frameWidth,
+                this.frameHeight,
+                this.x - this.frameWidth / 2,
+                this.y - this.frameHeight / 2,
+                this.frameWidth,
+                this.frameHeight
+            );
+        } else {
+            ctx.fillStyle = 'lime';
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
+            ctx.fill();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- render player using sprite-goblin.png with idle and walk animations
- prepare animation mappings for attack, hurt, and death frames

## Testing
- `npm run lint`
- `npm test` *(fails: libasound.so.2 missing)*
- `./setup-tests.sh` *(terminated early: apt-get install did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68b358d1b5548323be12b82686c8ddde