### PR TITLE
feat: add skeleton enemy with sprite animations

### DIFF
--- a/src/enemy.js
+++ b/src/enemy.js
@@ -1,0 +1,69 @@
+export default class Enemy {
+    constructor(canvas, gameState) {
+        this.canvas = canvas;
+        this.gameState = gameState;
+        this.x = Math.random() * canvas.width;
+        this.y = Math.random() * canvas.height;
+        this.speed = 1;
+        this.frameWidth = 32;
+        this.frameHeight = 32;
+        this.size = this.frameWidth / 2;
+        this.sprite = new Image();
+        this.sprite.src = 'img/sprite-skeleton.png';
+        this.animations = {
+            idle: { row: 0, frames: 2 },
+            walk: { row: 1, frames: 4 },
+            attack: { row: 2, frames: 2 },
+            death: { row: 3, frames: 2 }
+        };
+        this.state = 'walk';
+        this.frame = 0;
+        this.frameTimer = 0;
+        this.frameInterval = 15;
+    }
+
+    update() {
+        const player = this.gameState.player;
+        if (player) {
+            const dx = player.x - this.x;
+            const dy = player.y - this.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist > 0) {
+                this.x += (dx / dist) * this.speed;
+                this.y += (dy / dist) * this.speed;
+                this.state = 'walk';
+            } else {
+                this.state = 'idle';
+            }
+        }
+
+        this.frameTimer++;
+        if (this.frameTimer >= this.frameInterval) {
+            this.frameTimer = 0;
+            const animation = this.animations[this.state];
+            this.frame = (this.frame + 1) % animation.frames;
+        }
+    }
+
+    draw(ctx) {
+        const animation = this.animations[this.state];
+        if (this.sprite.complete) {
+            ctx.drawImage(
+                this.sprite,
+                this.frame * this.frameWidth,
+                animation.row * this.frameHeight,
+                this.frameWidth,
+                this.frameHeight,
+                this.x - this.frameWidth / 2,
+                this.y - this.frameHeight / 2,
+                this.frameWidth,
+                this.frameHeight
+            );
+        } else {
+            ctx.fillStyle = 'red';
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import Player from './player.js';
+import Enemy from './enemy.js';
 import { updateProjectiles, drawProjectiles } from './projectile.js';
 
 const canvas = document.getElementById('gameCanvas');
@@ -7,6 +8,7 @@ const ctx = canvas.getContext('2d');
 const gameState = window.gameState = {
     keys: {},
     player: null,
+    enemies: [],
     projectiles: []
 };
 
@@ -18,6 +20,14 @@ function drawPlayer() {
     gameState.player.draw(ctx);
 }
 
+function updateEnemies() {
+    gameState.enemies.forEach(enemy => enemy.update());
+}
+
+function drawEnemies() {
+    gameState.enemies.forEach(enemy => enemy.draw(ctx));
+}
+
 function clearCanvas() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 }
@@ -25,14 +35,17 @@ function clearCanvas() {
 function gameLoop() {
     clearCanvas();
     updatePlayer();
+    updateEnemies();
     updateProjectiles(gameState, canvas);
     drawPlayer();
+    drawEnemies();
     drawProjectiles(gameState, ctx);
     requestAnimationFrame(gameLoop);
 }
 
 function init() {
     gameState.player = new Player(canvas, gameState);
+    gameState.enemies.push(new Enemy(canvas, gameState));
     window.addEventListener('keydown', e => {
         gameState.keys[e.code] = true;
         if (e.code === 'Digit1') gameState.player.weapon = 'inferno';

--- a/tests/enemy.test.js
+++ b/tests/enemy.test.js
@@ -1,0 +1,27 @@
+import Enemy from '../src/enemy.js';
+
+beforeAll(() => {
+  globalThis.Image = class {
+    constructor() {
+      this.complete = true;
+    }
+  };
+});
+
+describe('Enemy', () => {
+  const createEnemy = () => {
+    const canvas = { width: 100, height: 100 };
+    const gameState = { player: { x: 80, y: 50 } };
+    const enemy = new Enemy(canvas, gameState);
+    enemy.x = 10;
+    enemy.y = 50;
+    return enemy;
+  };
+
+  test('moves toward the player', () => {
+    const enemy = createEnemy();
+    const initialX = enemy.x;
+    enemy.update();
+    expect(enemy.x).toBeGreaterThan(initialX);
+  });
+});


### PR DESCRIPTION
## Summary
- add Debt-Skeleton enemy with 32x32 sprite sheet animations
- integrate enemies into game loop and spawn a skeleton
- test skeleton pursuit behavior toward player

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3679adf0c8323a794f1899b780004