### PR TITLE
Add enemy spawner and AI implementations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -29,10 +29,10 @@ This document outlines a phased approach for the development of "Goblin's Infern
   * [x] The **Code Goblin** will create the base class for projectiles (fireballs) with properties for damage, speed, and size.
   * [x] The **Code Goblin** will implement the logic for the Inferno Blast, Flame Stream, and Volatile Orb starting weapons.
   * [ ] The **Asset Goblin** will create the visual particle effects and sprites for the fireballs.  
-* [ ] **2.3 Implement Enemy Spawning & AI:**  
-  * [ ] The **Code Goblin** will implement an enemy spawner that incrementally increases enemy count and difficulty over time.  
-  * [ ] The **Code Goblin** will create the AI scripts for Debt-Skeletons, Loaner-Imps, and Bailiff-Ogres.  
-  * [ ] The **Asset Goblin** will create the animated sprites for all standard enemies.  
+* [ ] **2.3 Implement Enemy Spawning & AI:**
+  * [x] The **Code Goblin** will implement an enemy spawner that incrementally increases enemy count and difficulty over time.
+  * [x] The **Code Goblin** will create the AI scripts for Debt-Skeletons, Loaner-Imps, and Bailiff-Ogres.
+  * [ ] The **Asset Goblin** will create the animated sprites for all standard enemies.
 * [ ] **2.4 Implement Level Up & Upgrade System:**  
   * [ ] The **Code Goblin** will implement a system to track collected gems and handle player level-ups.  
   * [ ] The **UI/UX Designer AI** will create the UI for the three random upgrade choices.  

--- a/src/enemy.js
+++ b/src/enemy.js
@@ -1,4 +1,4 @@
-export default class Enemy {
+export class Enemy {
     constructor(canvas, gameState) {
         this.canvas = canvas;
         this.gameState = gameState;
@@ -9,7 +9,6 @@ export default class Enemy {
         this.frameHeight = 32;
         this.size = this.frameWidth / 2;
         this.sprite = new Image();
-        this.sprite.src = 'img/sprite-skeleton.png';
         this.animations = {
             idle: { row: 0, frames: 2 },
             walk: { row: 1, frames: 4 },
@@ -20,6 +19,15 @@ export default class Enemy {
         this.frame = 0;
         this.frameTimer = 0;
         this.frameInterval = 15;
+    }
+
+    advanceFrame() {
+        this.frameTimer++;
+        if (this.frameTimer >= this.frameInterval) {
+            this.frameTimer = 0;
+            const animation = this.animations[this.state];
+            this.frame = (this.frame + 1) % animation.frames;
+        }
     }
 
     update() {
@@ -36,13 +44,7 @@ export default class Enemy {
                 this.state = 'idle';
             }
         }
-
-        this.frameTimer++;
-        if (this.frameTimer >= this.frameInterval) {
-            this.frameTimer = 0;
-            const animation = this.animations[this.state];
-            this.frame = (this.frame + 1) % animation.frames;
-        }
+        this.advanceFrame();
     }
 
     draw(ctx) {
@@ -65,5 +67,60 @@ export default class Enemy {
             ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
             ctx.fill();
         }
+    }
+}
+
+export class DebtSkeleton extends Enemy {
+    constructor(canvas, gameState) {
+        super(canvas, gameState);
+        this.speed = 1;
+        this.sprite.src = 'img/sprite-skeleton.png';
+    }
+}
+
+export class LoanerImp extends Enemy {
+    constructor(canvas, gameState) {
+        super(canvas, gameState);
+        this.speed = 2;
+        this.sprite.src = 'img/sprite-imp.png';
+        this.angle = Math.random() * Math.PI * 2;
+    }
+
+    update() {
+        super.update();
+        this.x += Math.sin(this.angle) * 2;
+        this.angle += 0.1;
+    }
+}
+
+export class BailiffOgre extends Enemy {
+    constructor(canvas, gameState) {
+        super(canvas, gameState);
+        this.speed = 0.75;
+        this.sprite.src = 'img/sprite-ogre.png';
+        this.chargeCooldown = 0;
+    }
+
+    update() {
+        const player = this.gameState.player;
+        if (player) {
+            const dx = player.x - this.x;
+            const dy = player.y - this.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist < 80 && this.chargeCooldown <= 0) {
+                this.x += (dx / dist) * this.speed * 4;
+                this.y += (dy / dist) * this.speed * 4;
+                this.state = 'attack';
+                this.chargeCooldown = 60;
+            } else if (dist > 0) {
+                this.x += (dx / dist) * this.speed;
+                this.y += (dy / dist) * this.speed;
+                this.state = 'walk';
+            } else {
+                this.state = 'idle';
+            }
+        }
+        if (this.chargeCooldown > 0) this.chargeCooldown--;
+        this.advanceFrame();
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import Player from './player.js';
-import Enemy from './enemy.js';
 import { updateProjectiles, drawProjectiles } from './projectile.js';
+import { updateSpawner } from './spawner.js';
 
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
@@ -9,7 +9,10 @@ const gameState = window.gameState = {
     keys: {},
     player: null,
     enemies: [],
-    projectiles: []
+    projectiles: [],
+    spawnTimer: 0,
+    spawnInterval: 120,
+    difficulty: 0
 };
 
 function updatePlayer() {
@@ -21,6 +24,7 @@ function drawPlayer() {
 }
 
 function updateEnemies() {
+    updateSpawner(gameState, canvas);
     gameState.enemies.forEach(enemy => enemy.update());
 }
 
@@ -45,7 +49,6 @@ function gameLoop() {
 
 function init() {
     gameState.player = new Player(canvas, gameState);
-    gameState.enemies.push(new Enemy(canvas, gameState));
     window.addEventListener('keydown', e => {
         gameState.keys[e.code] = true;
         if (e.code === 'Digit1') gameState.player.weapon = 'inferno';

--- a/src/spawner.js
+++ b/src/spawner.js
@@ -1,0 +1,20 @@
+import { DebtSkeleton, LoanerImp, BailiffOgre } from './enemy.js';
+
+export function updateSpawner(gameState, canvas) {
+    if (gameState.spawnTimer <= 0) {
+        const difficulty = gameState.difficulty;
+        const roll = Math.random();
+        let EnemyType = DebtSkeleton;
+        if (roll > 0.8 && difficulty > 20) {
+            EnemyType = BailiffOgre;
+        } else if (roll > 0.5 && difficulty > 10) {
+            EnemyType = LoanerImp;
+        }
+        gameState.enemies.push(new EnemyType(canvas, gameState));
+        gameState.spawnTimer = Math.max(30, gameState.spawnInterval - Math.floor(difficulty));
+        gameState.difficulty += 1;
+    } else {
+        gameState.spawnTimer--;
+        gameState.difficulty += 0.01;
+    }
+}

--- a/tests/enemy.test.js
+++ b/tests/enemy.test.js
@@ -1,4 +1,4 @@
-import Enemy from '../src/enemy.js';
+import { DebtSkeleton, LoanerImp, BailiffOgre } from '../src/enemy.js';
 
 beforeAll(() => {
   globalThis.Image = class {
@@ -8,20 +8,35 @@ beforeAll(() => {
   };
 });
 
-describe('Enemy', () => {
-  const createEnemy = () => {
-    const canvas = { width: 100, height: 100 };
-    const gameState = { player: { x: 80, y: 50 } };
-    const enemy = new Enemy(canvas, gameState);
+describe('Enemy Types', () => {
+  const canvas = { width: 100, height: 100 };
+  const gameState = { player: { x: 80, y: 50 } };
+
+  test('DebtSkeleton moves toward the player', () => {
+    const enemy = new DebtSkeleton(canvas, gameState);
     enemy.x = 10;
     enemy.y = 50;
-    return enemy;
-  };
-
-  test('moves toward the player', () => {
-    const enemy = createEnemy();
     const initialX = enemy.x;
     enemy.update();
     expect(enemy.x).toBeGreaterThan(initialX);
+  });
+
+  test('LoanerImp is faster than DebtSkeleton', () => {
+    const skeleton = new DebtSkeleton(canvas, gameState);
+    const imp = new LoanerImp(canvas, gameState);
+    skeleton.x = imp.x = 10;
+    skeleton.y = imp.y = 50;
+    skeleton.update();
+    imp.update();
+    expect(imp.x - 10).toBeGreaterThan(skeleton.x - 10);
+  });
+
+  test('BailiffOgre charges when close', () => {
+    const ogre = new BailiffOgre(canvas, gameState);
+    ogre.x = 70;
+    ogre.y = 50;
+    ogre.chargeCooldown = 0;
+    ogre.update();
+    expect(ogre.state).toBe('attack');
   });
 });

--- a/tests/spawner.test.js
+++ b/tests/spawner.test.js
@@ -1,0 +1,18 @@
+import { updateSpawner } from '../src/spawner.js';
+
+beforeAll(() => {
+  globalThis.Image = class {
+    constructor() {
+      this.complete = true;
+    }
+  };
+});
+
+describe('Enemy Spawner', () => {
+  test('spawns enemies when timer reaches zero', () => {
+    const canvas = { width: 100, height: 100 };
+    const gameState = { enemies: [], spawnTimer: 0, spawnInterval: 60, difficulty: 0 };
+    updateSpawner(gameState, canvas);
+    expect(gameState.enemies.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add enemy spawner that scales difficulty over time
- implement DebtSkeleton, LoanerImp, and BailiffOgre enemy classes
- track spawn progress in PLAN

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b369fa3fcc8323824ee942b4833c51