### PR TITLE
Add Tone.js MIDI soundtrack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 
 # WSL
 *:Zone.Identifier
+
+# Audio
+src/midi/*.mid

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
         check();
       })();
     </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tonejs/midi@2.0.27/build/Midi.min.js"></script>
 </head>
 <body>
     <div id="hud" class="hud">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,7 +7,7 @@ import { applyCharacterToPlayer } from './characters.js';
 import { updateHazards, drawHazards } from './hazard.js';
 import { initDecor, drawDecor } from './decor.js';
 import { updateBoss, drawBossHUD } from './boss.js';
-import { initAudio, playSound, setMuted } from './audio.js';
+import { initAudio, playSound, setMuted, playMusic } from './audio.js';
 import { preloadAll } from './preload.js';
 import { repay } from './debt.js';
 import { initMeta, applyMetaAtRunStart } from './meta.js';
@@ -444,6 +444,8 @@ function init() {
         applyMetaAtRunStart(gameState);
         if (charModal) charModal.style.display = 'none';
         if (typeof gameState._refreshDebtHUD === 'function') gameState._refreshDebtHUD();
+        setMuted(false);
+        playMusic();
     }
 
     if (btnGnorp) btnGnorp.addEventListener('click', () => startAs('Gnorp'));


### PR DESCRIPTION
## Summary
- Load Tone.js and MIDI parser from CDN in index.html
- Add playMusic helper that uses Tone.js to play `src/midi/alkan.mid` and integrate setMuted with Tone's destination
- Start background music when a character is chosen
- Ignore committed MIDI files and handle missing soundtrack gracefully

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c114c6f1d88323b1d67ee98ba30716