### PR TITLE
Persist audio mute preference

### DIFF
--- a/src/js/audio.js
+++ b/src/js/audio.js
@@ -7,6 +7,27 @@ const audioState = {
   output: null, // final node before destination (e.g., compressor or masterGain)
 };
 
+const MUTE_KEY = 'goblins-inferno:muted';
+
+function canStore() {
+  try { return typeof localStorage !== 'undefined'; } catch { return false; }
+}
+
+export function loadMuted() {
+  if (!canStore()) return true;
+  try {
+    const val = localStorage.getItem(MUTE_KEY);
+    return val === null ? true : val === '1';
+  } catch {
+    return true;
+  }
+}
+
+function saveMuted(muted) {
+  if (!canStore()) return;
+  try { localStorage.setItem(MUTE_KEY, muted ? '1' : '0'); } catch {}
+}
+
 export function initAudio() {
   if (typeof window === 'undefined' || typeof window.AudioContext === 'undefined') return;
   if (!audioState.ctx) {
@@ -38,6 +59,7 @@ export function setMuted(muted) {
   if (typeof window !== 'undefined' && window.Tone && window.Tone.Destination) {
     window.Tone.Destination.mute = muted;
   }
+  saveMuted(muted);
 }
 
 function beep({ freq = 440, duration = 0.08, type = 'sine', gain = 0.03 } = {}) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -7,7 +7,7 @@ import { applyCharacterToPlayer } from './characters.js';
 import { updateHazards, drawHazards } from './hazard.js';
 import { initDecor, drawDecor } from './decor.js';
 import { updateBoss, drawBossHUD } from './boss.js';
-import { initAudio, playSound, setMuted, playMusic } from './audio.js';
+import { initAudio, playSound, setMuted, playMusic, loadMuted } from './audio.js';
 import { preloadAll } from './preload.js';
 import { repay } from './debt.js';
 import { initMeta, applyMetaAtRunStart } from './meta.js';
@@ -417,8 +417,10 @@ function gameLoop() {
 function init() {
     resizeCanvas();
     initAudio();
-    // Start muted by default so no sounds play until user opts in
-    try { setMuted(true); } catch {}
+    const initialMuted = loadMuted();
+    let muted = initialMuted;
+    // Apply persisted mute preference (defaulting to muted)
+    try { setMuted(initialMuted); } catch {}
     initMeta(gameState);
     // Initialize debt & HUD
     gameState.debt = createDebtState({ initialDebt: 10000, autoRepayPerFrame: 0.1 });
@@ -444,7 +446,7 @@ function init() {
         applyMetaAtRunStart(gameState);
         if (charModal) charModal.style.display = 'none';
         if (typeof gameState._refreshDebtHUD === 'function') gameState._refreshDebtHUD();
-        setMuted(false);
+        setMuted(muted);
         playMusic();
     }
 
@@ -595,10 +597,9 @@ function init() {
             });
         }
     }
-    // Reflect initial muted state in UI and maintain toggle without closing the menu
-    let muted = true;
+    // Reflect muted state from storage and allow toggling without closing the menu
     if (btnMute) {
-        btnMute.textContent = 'Unmute';
+        btnMute.textContent = muted ? 'Unmute' : 'Mute';
         btnMute.addEventListener('click', () => {
             muted = !muted;
             setMuted(muted);

--- a/tests/audio.test.js
+++ b/tests/audio.test.js
@@ -1,8 +1,25 @@
-import { playSound, initAudio, setMuted } from '../src/js/audio.js';
+import { playSound, initAudio, setMuted, loadMuted } from '../src/js/audio.js';
 
-test('audio functions exist and are callable in Node', () => {
-  // In Node/Jest, initAudio should no-op and playSound should not throw
-  expect(() => initAudio()).not.toThrow();
-  expect(() => setMuted(true)).not.toThrow();
-  expect(() => playSound('fire')).not.toThrow();
+describe('audio helpers', () => {
+  beforeEach(() => {
+    const store = {};
+    global.localStorage = {
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => { store[k] = v; }
+    };
+  });
+
+  test('audio functions exist and are callable in Node', () => {
+    // In Node/Jest, initAudio should no-op and playSound should not throw
+    expect(() => initAudio()).not.toThrow();
+    expect(() => setMuted(true)).not.toThrow();
+    expect(() => playSound('fire')).not.toThrow();
+  });
+
+  test('setMuted persists preference', () => {
+    setMuted(true);
+    expect(loadMuted()).toBe(true);
+    setMuted(false);
+    expect(loadMuted()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- remember audio mute state using localStorage
- apply saved preference on startup and when toggling
- test persistence of audio mute state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c12597fedc8323af1a91a5daab2288