### PR TITLE
Align player HUD bar colors with boss

### DIFF
--- a/src/js/player.js
+++ b/src/js/player.js
@@ -228,10 +228,10 @@ export default class Player {
         const by = this.y - destH / 2 - 12;
         const frac = Math.max(0, Math.min(1, (this.hp || 0) / (this.maxHp || 1)));
         // Styled draw; if it throws for any reason, fall back
-        try { drawBar(ctx, 'hp', bx, by, barW, barH, frac); } catch {
+        try { drawBar(ctx, 'health', bx, by, barW, barH, frac); } catch {
             ctx.fillStyle = 'rgba(0,0,0,0.5)';
             ctx.fillRect(bx, by, barW, barH);
-            ctx.fillStyle = '#e33';
+            ctx.fillStyle = '#e84f39';
             ctx.fillRect(bx, by, barW * frac, barH);
             ctx.strokeStyle = 'rgba(255,255,255,0.2)';
             ctx.strokeRect(bx, by, barW, barH);
@@ -244,7 +244,7 @@ export default class Player {
             try { drawBar(ctx, 'shield', bx, sy, barW, barH, sFrac); } catch {
                 ctx.fillStyle = 'rgba(0,0,0,0.5)';
                 ctx.fillRect(bx, sy, barW, barH);
-                ctx.fillStyle = '#4aa3ff';
+                ctx.fillStyle = '#50aaff';
                 ctx.fillRect(bx, sy, barW * sFrac, barH);
                 ctx.strokeStyle = 'rgba(255,255,255,0.2)';
                 ctx.strokeRect(bx, sy, barW, barH);

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -36,8 +36,9 @@ function drawBarStyled(ctx, kind, x, y, w, h, frac) {
   if (fw > 0) {
     const grad = ctx.createLinearGradient(x, y, x, y + h);
     if (kind === 'shield') {
-      grad.addColorStop(0, '#5bcaff');
-      grad.addColorStop(1, '#3daeec');
+      // Match boss arrow colors for player shield bar
+      grad.addColorStop(0, '#50aaff');
+      grad.addColorStop(1, '#002850');
     } else { // health
       grad.addColorStop(0, '#e84f39');
       grad.addColorStop(1, '#d73e28');


### PR DESCRIPTION
## Summary
- Update shield bar gradient to use the boss arrow blue tones for consistency.
- Use "health" style and matching fallback colors for the player's health bar.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c13d9b062083239cbced242e011d42